### PR TITLE
Set SCB->VTOR to start of flash at boot

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -140,7 +140,7 @@ uint8_t getActiveBank() {
 int main(void)
 {
   /* USER CODE BEGIN 1 */
-
+  SCB->VTOR = 0x08000000;
   /* USER CODE END 1 */
 
   /* MCU Configuration--------------------------------------------------------*/


### PR DESCRIPTION
Fixes #3 , supposedly (I have no way to test this right now unfortunately)